### PR TITLE
Fix panel height not matching chat bar

### DIFF
--- a/Snippets/Simplified Panel Area/SimplifiedPanelArea.css
+++ b/Snippets/Simplified Panel Area/SimplifiedPanelArea.css
@@ -385,8 +385,6 @@
 /*UserPanel*/
 .container__37e49.container__37e49 {
   border-radius: 0 0 7px 7px;
-  height: unset;
-  padding: 0 !important;
   margin: 0;
   transition: background-color .2s ease;
   &:hover {


### PR DESCRIPTION
recent discord change made it so that the chat bar and the user panel are the same height, this style seemed to unset it for some reason.
Fixing that also makes the avatar feel not spaced evenly, so i removed the padding resetter to fix that too

before             |  after
:-------------------------:|:-------------------------:
<img width="408" height="87" alt="image" src="https://github.com/user-attachments/assets/1c5a286b-667c-4b68-ba65-ea8dece6ea10" />  |  <img width="408" height="87" alt="image" src="https://github.com/user-attachments/assets/e32b4774-d580-4e56-9b8a-76bd10377f12" />